### PR TITLE
Fix github workflow missing cache dep

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           node-version: "16"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
-          cache-dependency-path: ${{ env.BUILD_PATH }}/package-lock.json
+          cache-dependency-path: ${{ env.BUILD_PATH }}/yarn-lock.json
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3


### PR DESCRIPTION
The github workflow was using the incorrect `cache-dependency-path` which was causing an error and halting the automation.