### PR TITLE
Fix default environment and readme

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,6 @@ jobs:
         with:
           node-version: "16"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
-          cache-dependency-path: ${{ env.BUILD_PATH }}/yarn-lock.json
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3

--- a/README.md
+++ b/README.md
@@ -18,29 +18,40 @@ This tool is available on the web at [https://uphold.github.io/vault-assist-tool
 4. Specify the destination address you wish to move funds.
 5. Confirm and view transaction on chain
 
----
 
-## Development
+## Running Vault Assist Tool Locally
 
-The Uphold Vault Assist Tool is provided under the [MIT License](/LICENSE).
+### Installing Dependencies
 
-### Install dependencies
-
-To install the dependencies run:
+You must install these before you are able to run this locally:
 
 ```sh
 yarn install
 ```
 
-### Local Web Server
+### Start local web server
 
-To run this package locally:
+After the dependencies are installed, you should be able to run the server:
 
 ```sh
 yarn start
 ```
 
-**NOTE**: By default the local server uses [testnet](https://xrpl.org/parallel-networks.html) for development purposes.
+Then open a browser window at `http://127.0.0.1:3000/`
+
+## Development and testing
+
+The Uphold Vault Assist Tool is provided under the [MIT License](/LICENSE).
+
+### Start development server
+
+**Note**: You must install the dependencies as mentioned above before running this.
+
+To run the local web server using [testnet](https://xrpl.org/parallel-networks.html):
+
+```sh
+yarn dev
+```
 
 ### Testing
 
@@ -58,7 +69,7 @@ yarn e2e:optional
 
 ### Build
 
-**Note:** There is Github workflow is used to deploy this to the web.
+**Note:** There is a Github workflow which is used to deploy this to the web.
 
 To build the package (output to `public` directory):
 

--- a/package.json
+++ b/package.json
@@ -7,20 +7,20 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "predeploy": "NODE_CONFIG_DIR=./config bash -c 'webpack --config webpack.app.babel.js --node-env ${NODE_ENV:=production} --progress'",
+    "predeploy": "bash -c 'webpack --config webpack.app.babel.js --node-env ${NODE_ENV:=production} --progress'",
     "deploy": "gh-pages -d public",
-    "build": "NODE_CONFIG_DIR=./config bash -c 'webpack --config webpack.app.babel.js --node-env ${NODE_ENV:=production} --progress'",
-    "dev": "NODE_CONFIG_DIR=./config webpack serve --config webpack.app.babel.js",
+    "build": "bash -c 'webpack --config webpack.app.babel.js --node-env ${NODE_ENV:=production} --progress'",
+    "dev": "webpack serve --config webpack.app.babel.js --mode development --node-env ${NODE_ENV:=development}",
     "eslint": "eslint .",
     "cy:open": "cypress open",
     "cy:run": "cypress run --config excludeSpecPattern=test/cypress/integration/optional.spec.js",
     "cy:run-optional": "cypress run --config specPattern=test/cypress/integration/optional.spec.js",
-    "e2e": "start-server-and-test start http://localhost:3000 cy:run",
-    "e2e:optional": "start-server-and-test start http://localhost:3000 cy:run-optional",
+    "e2e": "start-server-and-test dev http://localhost:3000 cy:run",
+    "e2e:optional": "start-server-and-test dev http://localhost:3000 cy:run-optional",
     "lint": "yarn eslint && yarn stylelint src",
     "patch-package": "patch-package",
     "pre-commit": "lint-staged --relative",
-    "start": "NODE_CONFIG_DIR=./config webpack serve --config webpack.app.babel.js --mode development"
+    "start": "webpack serve --config webpack.app.babel.js --node-env ${NODE_ENV:=production}"
   },
   "pre-commit": "pre-commit",
   "lint-staged": {

--- a/src/lib/vault/index.js
+++ b/src/lib/vault/index.js
@@ -17,6 +17,9 @@ import {
 } from './xrpl-provider';
 import { translate } from '../../lib/i18n';
 
+// eslint-disable-next-line no-process-env
+const { NODE_ENV } = process.env;
+
 export const Blockchain = VaultBlockchain;
 export const { validateAddress, validateMnemonic } = ValidationUtils;
 export const { signTransaction } = WalletService;
@@ -36,7 +39,9 @@ export const getCurrency = blockchain => {
 export const getTransactionLink = (blockchain, hash) => {
   switch (blockchain) {
     case Blockchain.XRPL:
-      return __DEV__ ? `https://testnet.xrpl.org/transactions/${hash}` : `https://xrpscan.com/tx/${hash}`;
+      return NODE_ENV === 'production'
+        ? `https://livenet.xrpl.org/transactions/${hash}`
+        : `https://testnet.xrpl.org/transactions/${hash}`;
     default:
       break;
   }


### PR DESCRIPTION
- Change default env for `yarn start` to use mainnet instead of testnet
- The `yarn dev` script uses testnet instead of mainnet (since default is now mainnet)
- Readme updated to include instructions on how to start dev mode
- Fix build environment detection for explorer link for successful transaction page (it was using testnet even in production)
- Fix github workflow cache error